### PR TITLE
Add Icons and breadcrumbs

### DIFF
--- a/simple-parking/app/protected/properties/layout.tsx
+++ b/simple-parking/app/protected/properties/layout.tsx
@@ -1,0 +1,14 @@
+import BreadcrumbClient from "@/components/breadcrumb";
+
+export default async function PropertiesLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <div className="space-y-4 p-4">
+            <BreadcrumbClient/>
+            {children}
+        </div>
+    )
+}

--- a/simple-parking/components/breadcrumb.tsx
+++ b/simple-parking/components/breadcrumb.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbLink,
+    BreadcrumbList,
+    BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { usePathname } from "next/navigation"
+import Link from "next/link"
+
+export default function BreadcrumbClient(){
+    const pathname = usePathname()
+
+    const segments = pathname.split("/").filter(Boolean).slice(1) // remove 'protected'
+    const breadcrumbItems = segments.map((segment, index) => {
+        const href = "/" + segments.slice(0, index + 1).join("/")
+        const isLast = index === segments.length - 1
+        const label = decodeURIComponent(segment).replace(/-/g, " ").replace(/\b\w/g, l => l.toUpperCase())
+        return (
+            <span key={href} className="flex items-center">
+                {index > 0 && <BreadcrumbSeparator />}
+                <BreadcrumbItem>
+                    {isLast ? (
+                        <span className="text-muted-foreground">{label}</span>
+                    ) : (
+                        <BreadcrumbLink asChild>
+                            <Link href={href}>{label}</Link>
+                        </BreadcrumbLink>
+                    )}
+                </BreadcrumbItem>
+            </span>
+        )
+    })
+
+        return  (
+            <Breadcrumb>
+            <BreadcrumbList>{breadcrumbItems}</BreadcrumbList>
+            </Breadcrumb>
+        )
+}

--- a/simple-parking/components/dashboard-button.tsx
+++ b/simple-parking/components/dashboard-button.tsx
@@ -1,13 +1,17 @@
 "use client";
 import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
+import { LayoutDashboard } from "lucide-react";
+import Link from "next/link";
 
 export function DashboardButton() {
-  const router = useRouter();
 
-  const goToDashboard = async () => {
-    router.push("/protected/dashboard");
-  };
-
-  return <Button variant='outline' onClick={goToDashboard}>Dashboard</Button>;
+  return (
+    <Link href="/protected/dashboard" >
+      
+      <Button variant="outline">
+        <LayoutDashboard />
+        Dashboard
+        </Button>
+    </Link>
+  )
 }

--- a/simple-parking/components/manage-properties-button.tsx
+++ b/simple-parking/components/manage-properties-button.tsx
@@ -1,27 +1,15 @@
 import Link from "next/link";
 import { Button } from "./ui/button";
-import { getUser, getUserProperties } from "@/lib/supabase/property";
-import { cn } from "@/lib/utils";
+import { Building } from "lucide-react";
 
-type ManagePropertiesButtonProps = {
-    className?: string
-}
-export default async function ManagePropertiesButton({ className }: ManagePropertiesButtonProps) {
-    const user = await getUser()
-    if(user){
-        const {userProperties} = await getUserProperties(user.id)
-        if(userProperties){
-            const adminProperty = userProperties.find((userProperty) => (userProperty.role === 'admin'))
-            if(!adminProperty){
-                return null
-            }
-        }
-    }
-    return (
-        <div className={cn(className)}>
-            <Link href={`/protected/properties`}>
-                <Button variant="outline">Manage Properties</Button>
-            </Link>
-        </div>
-    )
+export default async function ManagePropertiesButton() {
+      return (
+    <Link href="/protected/properties" >
+      
+      <Button variant="outline">
+        <Building/>
+        Properties
+        </Button>
+    </Link>
+  )
 }

--- a/simple-parking/components/ui/breadcrumb.tsx
+++ b/simple-parking/components/ui/breadcrumb.tsx
@@ -1,0 +1,109 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("hover:text-foreground transition-colors", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("text-foreground font-normal", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/simple-parking/package-lock.json
+++ b/simple-parking/package-lock.json
@@ -1418,6 +1418,8 @@
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"


### PR DESCRIPTION
### Description
This PR improve dashboard by adding icons to dashboard and properties buttons. Adds breadcrumbs to property route.

### Task Completed
- Add layout icon to dashboard button
- rename 'manage properties' button to 'properties'
- Add building icon to properties button
- Install Shadcn breadcrumbs component
- Add layout in property route
- Create breadcrumbsClient component
- Add breadcrumbsClient to property layout